### PR TITLE
Harden trailer pipeline: require word timing, reject zero-duration clips, fail loudly

### DIFF
--- a/remotion/src/Root.tsx
+++ b/remotion/src/Root.tsx
@@ -93,10 +93,18 @@ const calculateDurationInFrames = (props: TrailerProps): number => {
   // Sum clip durations minus overlaps between them
   let clipsFrames = 0;
   for (let i = 0; i < props.clips.length; i++) {
-    clipsFrames += Math.ceil(props.clips[i].duration * FPS);
+    const clip = props.clips[i];
+    if (!(clip.duration > 0)) {
+      throw new Error(
+        `Trailer clip ${i} (scene ${clip.scene} dlg ${clip.dialogue_num}) has ` +
+          `non-positive duration ${clip.duration}. The trailer config is malformed — ` +
+          `regenerate it with scripts/llm_producer.py trailer.`,
+      );
+    }
+    clipsFrames += Math.ceil(clip.duration * FPS);
     // Subtract overlap for all clips after the first
     if (i > 0) {
-      clipsFrames -= OVERLAP_FRAMES[props.clips[i].transition] || 0;
+      clipsFrames -= OVERLAP_FRAMES[clip.transition] || 0;
     }
   }
 

--- a/remotion/src/Trailer.tsx
+++ b/remotion/src/Trailer.tsx
@@ -38,7 +38,7 @@ const ClipSchema = z.object({
   text: z.string(),
   start_sec: z.number(),
   end_sec: z.number(),
-  duration: z.number(),
+  duration: z.number().positive(),
   actor: z.string(),
   video_file: z.string().optional(),
   words: z.array(WordSchema).optional(),
@@ -47,7 +47,7 @@ const ClipSchema = z.object({
 const EndCardSchema = z.object({
   text: z.string(),
   subtext: z.string(),
-  duration: z.number(),
+  duration: z.number().positive(),
 });
 
 const ModulationSchema = z.object({

--- a/scripts/llm_producer.py
+++ b/scripts/llm_producer.py
@@ -43,6 +43,10 @@ DEFAULT_MODEL = "moonshotai/kimi-k2.5"
 # Trailer constants
 TRANSITIONS = ["hard-cut", "flash-white", "flash-black", "zoom-punch", "glitch", "side-scroll-left", "split"]
 
+# Minimum number of usable clips required to produce a trailer config.
+# Below this, abort with a clear error rather than write a degenerate config.
+MIN_TRAILER_CLIPS = 5
+
 # ============================================================================
 # System Prompts
 # ============================================================================
@@ -177,6 +181,11 @@ def compress_for_llm(session_log: dict, mode: str = "clips") -> dict:
             if not line:
                 continue
 
+            # Trailer mode requires word-level timing for partial selection.
+            # Skip dialogues without it so the LLM can't pick them.
+            if mode == "trailer" and not d.get("words"):
+                continue
+
             entry = {
                 "i": d.get("number", 0),
                 "t": format_time(d.get("startSec", 0)),
@@ -184,10 +193,8 @@ def compress_for_llm(session_log: dict, mode: str = "clips") -> dict:
                 "l": line
             }
 
-            # Trailer mode includes word count for partial selection
             if mode == "trailer":
-                words = d.get("words", [])
-                entry["w"] = len(words)
+                entry["w"] = len(d["words"])
 
             dialogue.append(entry)
 
@@ -635,32 +642,36 @@ class TrailerConfig:
     generated_at: str = ""
 
 
-def extract_partial_line(dialogue: dict, start_word: int, end_word: int) -> dict:
-    """Extract timing for partial line using word-level timestamps."""
+def extract_partial_line(dialogue: dict, start_word: int, end_word: int) -> Optional[dict]:
+    """Extract timing for partial line using word-level timestamps.
+
+    Returns None when the dialogue cannot be turned into a usable trailer clip.
+    The trailer pipeline needs word boundaries to extract 1–3 second partials,
+    so dialogues with an empty `words` array are unusable — there is no
+    meaningful fallback to dialogue-level timing for partial selection.
+    """
     words = dialogue.get("words", [])
+    if not words:
+        return None
 
     start_word = max(0, min(start_word, len(words) - 1))
     end_word = max(start_word, min(end_word, len(words) - 1))
-
-    if not words:
-        return {
-            "text": dialogue.get("line", ""),
-            "startSec": dialogue.get("startSec", 0),
-            "endSec": dialogue.get("endSec", 0),
-            "duration": dialogue.get("endSec", 0) - dialogue.get("startSec", 0)
-        }
 
     partial_words = words[start_word:end_word + 1]
     text = " ".join(w["word"] for w in partial_words)
 
     start_sec = partial_words[0]["start"]
     end_sec = partial_words[-1]["end"]
+    duration = end_sec - start_sec
+
+    if duration <= 0:
+        return None
 
     return {
         "text": text,
         "startSec": start_sec,
         "endSec": end_sec,
-        "duration": end_sec - start_sec,
+        "duration": duration,
         "words": [{"word": w["word"], "start": w["start"], "end": w["end"]} for w in partial_words]
     }
 
@@ -731,6 +742,10 @@ def resolve_clips(raw_clips: list[dict], session_log: dict, session_log_path: Pa
             end_word = len(words) - 1
 
         partial = extract_partial_line(dialogue, start_word, end_word)
+        if partial is None:
+            print(f"  Warning: Skipping scene {scene_num} dlg {dialogue_num} "
+                  f"({dialogue.get('actor', '?')}): no usable word-level timing")
+            continue
 
         clip = TrailerClip(
             source=str(session_log_path),
@@ -909,9 +924,19 @@ def generate_trailer_config(
 
     clips = resolve_clips(raw_clips, session_log, session_log_path)
 
-    if not clips:
-        print("Warning: No valid clips resolved")
-        return None
+    if len(clips) < MIN_TRAILER_CLIPS:
+        print(
+            f"\nERROR: Only {len(clips)} usable clip(s) resolved "
+            f"(need at least {MIN_TRAILER_CLIPS}).",
+            file=sys.stderr,
+        )
+        print(
+            "This usually means the session log is missing word-level "
+            "transcription for many dialogues. Re-check the recording / ASR "
+            "step before retrying.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
 
     title_duration = 2.0
     end_card_duration = 2.0


### PR DESCRIPTION
## Why

The 2026-04-07 pipeline run (documented in a local diagnosis) showed the trailer step can fail silently: dialogues without word-level ASR timing produced zero-duration clips, and `llm_producer.py` exited 0 regardless, so `run_pipeline.sh` reported success with no trailer.

## Changes

- **scripts/llm_producer.py**
  - Trailer-mode LLM payload now excludes dialogues that lack word-level timing, so the model can't select unusable lines.
  - `extract_partial_line()` returns `None` for dialogues with no words or non-positive duration (previously fell back to dialogue-level timing, producing broken partials); callers skip those clips with a warning.
  - If fewer than `MIN_TRAILER_CLIPS` (5) usable clips resolve, the script prints a diagnostic and exits 1 instead of writing a degenerate config — `SystemExit` propagates past the `except Exception` handler in `cmd_trailer`, so the pipeline actually sees the failure.
- **remotion/src/Trailer.tsx**: zod schema requires `duration` to be positive for clips and the end card.
- **remotion/src/Root.tsx**: `calculateDurationInFrames` throws a descriptive error on non-positive clip durations, pointing at the malformed config.

## Verification

- `npx tsc --noEmit` in `remotion/` — clean.
- `llm_producer.py trailer --dry-run` on the 2026-05-31 episode session log — works, word counts included.
- Unit checks: `extract_partial_line` returns None for empty/zero-duration word spans and correct timing for valid ones; trailer-mode compression drops word-less dialogues while clips mode keeps them.

## Follow-up (not in this PR)

`cmd_trailer` / `cmd_clips` still catch API errors (e.g. OpenRouter 402) and exit 0 — a per-file failure counter with a non-zero exit would let the pipeline catch those too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)