### PR TITLE
OG share cards with pretext-measured headlines

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -47,6 +47,12 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      # Must run before the Astro build: pages check media/og/ at build time
+      # to decide their og:image meta tags.
+      - name: Generate OG share cards
+        continue-on-error: true
+        run: node scripts/og-cards.cjs --limit 60
+
       - name: Build Astro site
         run: npm run build
 
@@ -57,6 +63,7 @@ jobs:
           cp -r media/daily dist/media/daily 2>/dev/null || true
           cp -r media/dashboards dist/media/dashboards 2>/dev/null || true
           cp -r rss/ dist/rss/ 2>/dev/null || true
+          cp -r media/og dist/media/og 2>/dev/null || true
           cp -r scripts/posters/characters/ dist/scripts/posters/characters/ 2>/dev/null || true
           mkdir -p dist/api/data
           cp knowledge/api/manifest.json dist/api/data/manifest.json 2>/dev/null || true

--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,6 @@ episodes/trailers/
 # Local working directories (not source)
 media/data/
 media/samples/
+
+# Generated OG share cards (regenerated each deploy by scripts/og-cards.cjs)
+media/og/

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@astrojs/react": "^4.0.0",
         "@astrojs/sitemap": "^3.7.0",
+        "@chenglou/pretext": "^0.0.8",
         "astro": "^5.0.0",
         "puppeteer-stream": "^3.0.22",
         "react": "^18.3.1",
@@ -20,6 +21,7 @@
         "@types/react": "^18.3.0",
         "@types/react-dom": "^18.3.0",
         "glob": "^13.0.0",
+        "puppeteer": "^25.4.0",
         "ts-node": "^10.9.2",
         "typescript": "^5.8.3"
       }
@@ -400,6 +402,12 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/@chenglou/pretext": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/@chenglou/pretext/-/pretext-0.0.8.tgz",
+      "integrity": "sha512-yqm2GMxnPI7VHcHwe84P8ZF0JK/2d2DMKPqMN+s95jQhwDMYYXKVFVJUMEaVWckQStdsjdLav/0Vu+d9YbtGxA==",
+      "license": "MIT"
     },
     "node_modules/@cspotcode/source-map-support": {
       "version": "0.8.1",
@@ -4059,6 +4067,19 @@
         "node": ">=6"
       }
     },
+    "node_modules/lilconfig": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
+      "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antonk52"
+      }
+    },
     "node_modules/longest-streak": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
@@ -4953,6 +4974,16 @@
       "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
       "license": "MIT"
     },
+    "node_modules/modern-tar": {
+      "version": "0.7.7",
+      "resolved": "https://registry.npmjs.org/modern-tar/-/modern-tar-0.7.7.tgz",
+      "integrity": "sha512-t9VmxaqrmANnEOBhpSDI6HD192Ge48k8vmWqQQL7hSFEqHEYwZbbsu49+aKLWZeRvFs3j1pMhXOqqF4kPlvjkQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/mrmime": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.1.tgz",
@@ -5383,6 +5414,28 @@
         "once": "^1.3.1"
       }
     },
+    "node_modules/puppeteer": {
+      "version": "25.4.0",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-25.4.0.tgz",
+      "integrity": "sha512-xfQp8dFBcGaLc1hEMaVr7s+oW4ZkAurr8Y9H81ilKhu6QoLfSTkZjU7IavnyJ/VWpB9ni3KNJUQHUatslLWyGw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@puppeteer/browsers": "3.0.6",
+        "chromium-bidi": "17.0.2",
+        "devtools-protocol": "0.0.1653615",
+        "lilconfig": "^3.1.3",
+        "puppeteer-core": "25.4.0",
+        "typed-query-selector": "^2.12.2"
+      },
+      "bin": {
+        "puppeteer": "lib/puppeteer/node/cli.js"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
     "node_modules/puppeteer-core": {
       "version": "24.43.1",
       "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-24.43.1.tgz",
@@ -5409,6 +5462,154 @@
       "dependencies": {
         "puppeteer-core": "^24.16.2",
         "ws": "^8.17.1"
+      }
+    },
+    "node_modules/puppeteer/node_modules/@puppeteer/browsers": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-3.0.6.tgz",
+      "integrity": "sha512-B/gKoqlFkzhvzsI6jo9K1cZz9o5ypviVv/xu8CwA4grZzyVwN+XfkT+tu8T1zrauuEXv6VhS2oGX+6NL95WcKA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "modern-tar": "^0.7.6",
+        "yargs": "^18.0.0"
+      },
+      "bin": {
+        "browsers": "lib/main-cli.js"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      },
+      "peerDependencies": {
+        "proxy-agent": ">=8.0.1",
+        "yauzl": "^2.10.0 || ^3.4.0"
+      },
+      "peerDependenciesMeta": {
+        "proxy-agent": {
+          "optional": true
+        },
+        "yauzl": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/puppeteer/node_modules/chromium-bidi": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-17.0.2.tgz",
+      "integrity": "sha512-5v9GQFhTktFvotn/OFNJBmKLKRAb6n9r0bVCwf7sHgWc3/JryK0bj1nn93L3pHFrfgcsu6Be6EWsDi+1XHTGDg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "mitt": "^3.0.1",
+        "zod": "^3.24.1"
+      },
+      "engines": {
+        "node": ">=20.19.0 <22.0.0 || >=22.12.0"
+      },
+      "peerDependencies": {
+        "devtools-protocol": "*"
+      }
+    },
+    "node_modules/puppeteer/node_modules/cliui": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-9.0.1.tgz",
+      "integrity": "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^7.2.0",
+        "strip-ansi": "^7.1.0",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/puppeteer/node_modules/devtools-protocol": {
+      "version": "0.0.1653615",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1653615.tgz",
+      "integrity": "sha512-pGVkY3T/qXxAp2nFPodwYqOevk6ncNMSmvL8QfRCx5ZWGd6Vor7AFNmyaA8Zs6uJyP1QAfjuLandCgvSix1BNA==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/puppeteer/node_modules/puppeteer-core": {
+      "version": "25.4.0",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-25.4.0.tgz",
+      "integrity": "sha512-K1plkLOdeoUnGeT1OvdqF3qxl33v+Ra/uH5VyPEhXdMcpvGiEskHzxxEU3fgpccJpJLIipB/rPUsvkZRWeKqOA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@puppeteer/browsers": "3.0.6",
+        "chromium-bidi": "17.0.2",
+        "devtools-protocol": "0.0.1653615",
+        "typed-query-selector": "^2.12.2",
+        "webdriver-bidi-protocol": "0.4.2",
+        "ws": "^8.21.1"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/puppeteer/node_modules/webdriver-bidi-protocol": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/webdriver-bidi-protocol/-/webdriver-bidi-protocol-0.4.2.tgz",
+      "integrity": "sha512-VSV+fzfChirL3e7jay2yUC7B4HQCGtEWEg/MSSQbK+qWbqeGlRLlXTzPpYr3XGUvbpDHumWZBJxgesg4N7dbtA==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/puppeteer/node_modules/yargs": {
+      "version": "18.1.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-18.1.0.tgz",
+      "integrity": "sha512-2rAgRKu54VsHkqI0/tYkmluGXHD4KW7yZoycuqDQ15QOTnc2VVfy0nN/1eMhnQLO00A+dwtK20xuCnc1YGeUyg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^9.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "string-width": "^8.2.1",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^22.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
+      }
+    },
+    "node_modules/puppeteer/node_modules/yargs-parser": {
+      "version": "22.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
+      "integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
+      }
+    },
+    "node_modules/puppeteer/node_modules/yargs/node_modules/string-width": {
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.2.tgz",
+      "integrity": "sha512-GaPUh5gfdrYzqeVNZvUfT23vYYxXzKYidUcnMtJg/3rxRV63EFZy3k6xfKlmfeJD0176lnUV/Usr3XcwSvFzpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.5.0",
+        "strip-ansi": "^7.1.2"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/puppeteer/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/radix3": {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "build": "astro build",
     "preview": "astro preview",
     "sync": "git -C knowledge pull --ff-only origin main",
+    "og-cards": "node scripts/og-cards.cjs",
     "record": "node scripts/recorder.cjs",
     "pipeline": "./scripts/run_pipeline.sh",
     "clip": "npx ts-node scripts/clip.ts",
@@ -22,6 +23,7 @@
   "dependencies": {
     "@astrojs/react": "^4.0.0",
     "@astrojs/sitemap": "^3.7.0",
+    "@chenglou/pretext": "^0.0.8",
     "astro": "^5.0.0",
     "puppeteer-stream": "^3.0.22",
     "react": "^18.3.1",
@@ -32,6 +34,7 @@
     "@types/react": "^18.3.0",
     "@types/react-dom": "^18.3.0",
     "glob": "^13.0.0",
+    "puppeteer": "^25.4.0",
     "ts-node": "^10.9.2",
     "typescript": "^5.8.3"
   }

--- a/scripts/og-cards.cjs
+++ b/scripts/og-cards.cjs
@@ -1,0 +1,176 @@
+#!/usr/bin/env node
+/**
+ * Generate 1200x630 og:image share cards for daily + council pages.
+ *
+ * Headlines are wrapped with @chenglou/pretext (measured line breaking) drawn
+ * over the day's poster art, inside a headless Chrome page — pretext is
+ * browser-only (Intl.Segmenter + Canvas 2D), so all layout happens in-page
+ * via scripts/og/template.html.
+ *
+ * Usage:
+ *   node scripts/og-cards.cjs                 # all dates with usable facts
+ *   node scripts/og-cards.cjs --date 2026-07-19
+ *   node scripts/og-cards.cjs --force         # regenerate existing
+ *   node scripts/og-cards.cjs --limit 30
+ *
+ * Output: media/og/<date>.png and media/og/council-<date>.png
+ */
+
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+const { execFileSync } = require('node:child_process');
+
+const ROOT = path.resolve(__dirname, '..');
+const KNOWLEDGE_ROOT = process.env.KNOWLEDGE_ROOT || path.join(ROOT, 'knowledge');
+const OUT_DIR = path.join(ROOT, 'media', 'og');
+const TEMPLATE = path.join(__dirname, 'og', 'template.html');
+
+function parseArgs() {
+  const args = { force: false, date: null, limit: Infinity };
+  const argv = process.argv.slice(2);
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === '--force') args.force = true;
+    else if (argv[i] === '--date') args.date = argv[++i];
+    else if (argv[i] === '--limit') args.limit = parseInt(argv[++i], 10);
+  }
+  return args;
+}
+
+function readJson(p) {
+  try { return JSON.parse(fs.readFileSync(p, 'utf-8')); } catch { return null; }
+}
+
+function firstSentence(text, maxLen = 140) {
+  if (!text) return null;
+  const match = text.match(/^(.+?[.!?])(?=\s|$)/);
+  let s = match ? match[1] : text;
+  if (s.length > maxLen) s = s.substring(0, maxLen).replace(/\s+\S*$/, '') + '…';
+  return s.trim();
+}
+
+function formatDateLabel(date) {
+  const [y, m, d] = date.split('-').map(Number);
+  const dt = new Date(Date.UTC(y, m - 1, d));
+  return dt.toLocaleDateString('en-US', { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric', timeZone: 'UTC' });
+}
+
+function posterDataUrl(date) {
+  const p = path.join(ROOT, 'media', 'daily', date, 'overall.png');
+  if (!fs.existsSync(p)) return null;
+  return `data:image/png;base64,${fs.readFileSync(p).toString('base64')}`;
+}
+
+/** Bundle pretext into a single IIFE exposing window.pretext for addScriptTag. */
+function bundlePretext() {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'og-pretext-'));
+  const out = path.join(tmp, 'pretext.iife.js');
+  const entry = require.resolve('@chenglou/pretext', { paths: [ROOT] });
+  const esbuild = path.join(ROOT, 'node_modules', '.bin', 'esbuild');
+  execFileSync(esbuild, [entry, '--bundle', '--format=iife', '--global-name=pretext', `--outfile=${out}`], {
+    cwd: ROOT,
+    stdio: ['ignore', 'ignore', 'inherit'],
+  });
+  return out;
+}
+
+function collectJobs(args) {
+  const factsDir = path.join(KNOWLEDGE_ROOT, 'the-council', 'facts');
+  const briefingDir = path.join(KNOWLEDGE_ROOT, 'the-council', 'council_briefing');
+  let dates;
+  if (args.date) {
+    dates = [args.date];
+  } else {
+    dates = fs.readdirSync(factsDir)
+      .filter(f => /^\d{4}-\d{2}-\d{2}\.json$/.test(f))
+      .map(f => f.replace('.json', ''))
+      .sort()
+      .reverse()
+      .slice(0, args.limit === Infinity ? undefined : args.limit);
+  }
+
+  const jobs = [];
+  for (const date of dates) {
+    const dateLabel = formatDateLabel(date);
+    const poster = posterDataUrl(date);
+
+    const facts = readJson(path.join(factsDir, `${date}.json`));
+    // Skip LLM error placeholders — no headline worth sharing.
+    if (facts && facts._metadata?.status !== 'error' && facts.overall_summary && !/^Error:/i.test(facts.overall_summary)) {
+      jobs.push({
+        out: path.join(OUT_DIR, `${date}.png`),
+        payload: {
+          headline: firstSentence(facts.overall_summary),
+          kicker: 'Daily Briefing',
+          dateLabel,
+          posterDataUrl: poster,
+        },
+      });
+    }
+
+    const briefing = readJson(path.join(briefingDir, `${date}.json`));
+    if (briefing?.daily_focus && !/^Error/i.test(briefing.daily_focus)) {
+      jobs.push({
+        out: path.join(OUT_DIR, `council-${date}.png`),
+        payload: {
+          headline: firstSentence(briefing.daily_focus),
+          kicker: 'Council Briefing',
+          dateLabel,
+          posterDataUrl: poster,
+        },
+      });
+    }
+  }
+  return jobs;
+}
+
+async function main() {
+  const args = parseArgs();
+  fs.mkdirSync(OUT_DIR, { recursive: true });
+
+  let jobs = collectJobs(args);
+  if (!args.force) {
+    const skipped = jobs.filter(j => fs.existsSync(j.out)).length;
+    jobs = jobs.filter(j => !fs.existsSync(j.out));
+    if (skipped) console.log(`Skipping ${skipped} existing card(s) (use --force to regenerate)`);
+  }
+  if (jobs.length === 0) {
+    console.log('Nothing to generate.');
+    return;
+  }
+  console.log(`Generating ${jobs.length} card(s)…`);
+
+  const pretextBundle = bundlePretext();
+  const puppeteer = require('puppeteer');
+  const browser = await puppeteer.launch({ headless: true, args: ['--no-sandbox', '--force-color-profile=srgb'] });
+  let failed = 0;
+  try {
+    const page = await browser.newPage();
+    await page.goto(`file://${TEMPLATE}`, { waitUntil: 'networkidle0' });
+    await page.addScriptTag({ path: pretextBundle });
+
+    for (const job of jobs) {
+      try {
+        const dataUrl = await page.evaluate((payload) => window.renderCard(payload), job.payload);
+        fs.writeFileSync(job.out, Buffer.from(dataUrl.split(',')[1], 'base64'));
+        console.log(`  ✓ ${path.relative(ROOT, job.out)}`);
+      } catch (err) {
+        failed++;
+        console.error(`  ✗ ${path.relative(ROOT, job.out)}: ${err.message}`);
+      }
+    }
+  } finally {
+    await browser.close();
+  }
+
+  if (failed === jobs.length) {
+    console.error('All cards failed to generate.');
+    process.exit(1);
+  }
+  if (failed) console.warn(`${failed}/${jobs.length} card(s) failed; the rest were written.`);
+}
+
+main().catch(err => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/og/template.html
+++ b/scripts/og/template.html
@@ -1,0 +1,145 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>OG Card Template</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@700;900&family=DM+Sans:wght@500;700&display=swap" rel="stylesheet">
+<style>body { margin: 0; background: #222; }</style>
+</head>
+<body>
+<canvas id="card" width="1200" height="630"></canvas>
+<script>
+// The og-cards.cjs driver injects the pretext bundle as window.pretext
+// (IIFE global) before calling renderCard.
+
+const W = 1200;
+const H = 630;
+const MARGIN = 72;
+const HEADLINE_FAMILY = '"Playfair Display"';
+const UI_FAMILY = '"DM Sans"';
+
+const headlineFont = (px) => `900 ${px}px ${HEADLINE_FAMILY}`;
+const LINE_HEIGHT_RATIO = 1.12;
+
+async function ensureFonts() {
+  // Load the exact shorthands used for measurement AND drawing — pretext
+  // requires them to agree, and fillText silently falls back otherwise.
+  await Promise.all([
+    document.fonts.load(headlineFont(64), 'AGI'),
+    document.fonts.load(`700 42px ${UI_FAMILY}`, 'elizaOS'),
+    document.fonts.load(`500 28px ${UI_FAMILY}`, '2026'),
+  ]);
+  await document.fonts.ready;
+  if (!document.fonts.check(headlineFont(64))) {
+    throw new Error('Playfair Display failed to load — refusing to render with fallback font');
+  }
+}
+
+function fitHeadlineSize(text, maxWidth, maxLines, min = 40, max = 72) {
+  // Largest size in [min, max] whose layout fits maxLines.
+  let lo = min, hi = max, best = min;
+  while (lo <= hi) {
+    const mid = Math.floor((lo + hi) / 2);
+    const prepared = window.pretext.prepare(text, headlineFont(mid));
+    const { lineCount } = window.pretext.layout(prepared, maxWidth, Math.round(mid * LINE_HEIGHT_RATIO));
+    if (lineCount <= maxLines && lineCount > 0) { best = mid; lo = mid + 1; }
+    else hi = mid - 1;
+  }
+  return best;
+}
+
+function loadImage(dataUrl) {
+  return new Promise((resolve, reject) => {
+    const img = new Image();
+    img.onload = () => resolve(img);
+    img.onerror = () => reject(new Error('poster image failed to decode'));
+    img.src = dataUrl;
+  });
+}
+
+function drawCover(ctx, img) {
+  // object-fit: cover for the 1200x630 canvas
+  const scale = Math.max(W / img.width, H / img.height);
+  const dw = img.width * scale, dh = img.height * scale;
+  ctx.drawImage(img, (W - dw) / 2, (H - dh) / 2, dw, dh);
+}
+
+// payload: { headline, kicker, dateLabel, posterDataUrl }
+window.renderCard = async function renderCard(payload) {
+  await ensureFonts();
+  const canvas = document.getElementById('card');
+  const ctx = canvas.getContext('2d');
+  ctx.clearRect(0, 0, W, H);
+
+  const hasPoster = Boolean(payload.posterDataUrl);
+  if (hasPoster) {
+    drawCover(ctx, await loadImage(payload.posterDataUrl));
+    const scrim = ctx.createLinearGradient(0, H * 0.25, 0, H);
+    scrim.addColorStop(0, 'rgba(12, 12, 14, 0)');
+    scrim.addColorStop(0.45, 'rgba(12, 12, 14, 0.62)');
+    scrim.addColorStop(1, 'rgba(12, 12, 14, 0.92)');
+    ctx.fillStyle = scrim;
+    ctx.fillRect(0, 0, W, H);
+  } else {
+    // Branded fallback: newsprint cream with double rule, matching the site masthead.
+    ctx.fillStyle = '#f4efe4';
+    ctx.fillRect(0, 0, W, H);
+    ctx.fillStyle = '#1a1a1a';
+    ctx.fillRect(MARGIN, 52, W - 2 * MARGIN, 4);
+    ctx.fillRect(MARGIN, 62, W - 2 * MARGIN, 1);
+    ctx.fillRect(MARGIN, H - 40, W - 2 * MARGIN, 1);
+    ctx.fillRect(MARGIN, H - 33, W - 2 * MARGIN, 4);
+  }
+
+  const ink = hasPoster ? '#ffffff' : '#1a1a1a';
+  const accent = hasPoster ? 'rgba(255,255,255,0.82)' : '#5a5346';
+  const maxWidth = W - 2 * MARGIN;
+
+  // Headline: binary-search the largest size fitting <=3 lines, then draw
+  // the measured lines bottom-anchored.
+  const headline = payload.headline || 'Daily Intelligence Briefing';
+  const size = fitHeadlineSize(headline, maxWidth, 3);
+  const lineHeight = Math.round(size * LINE_HEIGHT_RATIO);
+  const font = headlineFont(size);
+  const prepared = window.pretext.prepareWithSegments(headline, font);
+  const { lines } = window.pretext.layoutWithLines(prepared, maxWidth, lineHeight);
+
+  ctx.font = font;
+  ctx.fillStyle = ink;
+  ctx.textBaseline = 'alphabetic';
+  if (hasPoster) {
+    ctx.shadowColor = 'rgba(0,0,0,0.55)';
+    ctx.shadowBlur = 14;
+    ctx.shadowOffsetY = 2;
+  }
+  const footerY = H - 64;                       // date line sits here
+  const headlineBottom = footerY - 44;          // gap above footer
+  const firstBaseline = headlineBottom - (lines.length - 1) * lineHeight;
+  for (let i = 0; i < lines.length; i++) {
+    ctx.fillText(lines[i].text, MARGIN, firstBaseline + i * lineHeight);
+  }
+  ctx.shadowColor = 'transparent';
+  ctx.shadowBlur = 0;
+  ctx.shadowOffsetY = 0;
+
+  // Kicker above the headline
+  ctx.font = `700 26px ${UI_FAMILY}`;
+  ctx.fillStyle = accent;
+  const kickerY = firstBaseline - lineHeight * 0.85 - 18;
+  ctx.fillText((payload.kicker || 'DAILY BRIEFING').toUpperCase(), MARGIN, kickerY);
+
+  // Masthead top-left, date bottom-left
+  ctx.font = `700 42px ${UI_FAMILY}`;
+  ctx.fillStyle = ink;
+  ctx.fillText('elizaOS News', MARGIN, hasPoster ? 104 : 128);
+  ctx.font = `500 28px ${UI_FAMILY}`;
+  ctx.fillStyle = accent;
+  ctx.fillText(payload.dateLabel || '', MARGIN, footerY + 10);
+
+  return canvas.toDataURL('image/png');
+};
+</script>
+</body>
+</html>

--- a/src/lib/data-loader.ts
+++ b/src/lib/data-loader.ts
@@ -58,6 +58,16 @@ export function getDailySilk(date: string): string | null {
   return readText(`daily-silk/${date}.md`);
 }
 
+const SITE_ORIGIN = 'https://elizaos.news';
+
+/** Absolute URL of a generated OG share card, or null if scripts/og-cards.cjs
+ * hasn't produced one for this date (cards are generated pre-build in CI). */
+export function getOgImagePath(date: string, kind: 'daily' | 'council'): string | null {
+  const file = kind === 'council' ? `council-${date}.png` : `${date}.png`;
+  const full = path.resolve(process.cwd(), 'media', 'og', file);
+  return fs.existsSync(full) ? `${SITE_ORIGIN}/media/og/${file}` : null;
+}
+
 export function getAvailableDates(type: 'facts' | 'council_briefing'): string[] {
   const dir = type === 'facts' ? 'the-council/facts' : 'the-council/council_briefing';
   try {

--- a/src/pages/council/[date].astro
+++ b/src/pages/council/[date].astro
@@ -4,7 +4,7 @@ import DatePicker from '../../components/nav/DatePicker';
 import MeetingContext from '../../components/council/MeetingContext';
 import DailyFocus from '../../components/council/DailyFocus';
 import DeliberationCard from '../../components/council/DeliberationCard.astro';
-import { getCouncilBriefing, getAvailableDates, getLatestDate } from '../../lib/data-loader';
+import { getCouncilBriefing, getAvailableDates, getLatestDate, getOgImagePath } from '../../lib/data-loader';
 
 export function getStaticPaths() {
   const dates = getAvailableDates('council_briefing');
@@ -33,8 +33,9 @@ function contextToHtml(md: string): string {
 const contextHtml = contextToHtml(briefing.meeting_context || '');
 const description = briefing.daily_focus?.substring(0, 160) || 'Council Strategic Deliberation';
 const keyPoints = briefing.key_points || [];
+const ogImage = getOgImagePath(date!, 'council') ?? undefined;
 ---
-<DarkLayout title={`Council Briefing - ${date}`} description={description} active="council">
+<DarkLayout title={`Council Briefing - ${date}`} description={description} ogImage={ogImage} active="council">
   <style is:global>
     @import '../../styles/dark.css';
 

--- a/src/pages/daily/[date].astro
+++ b/src/pages/daily/[date].astro
@@ -11,7 +11,7 @@ import DevelopmentGrid from '../../components/daily/DevelopmentGrid.astro';
 import FullStories from '../../components/daily/FullStories.astro';
 import OpenQuestions from '../../components/daily/OpenQuestions.astro';
 import GitHubStatsBar from '../../components/daily/GitHubStatsBar.astro';
-import { getFacts, getCouncilBriefing, getHighlights, getAiNews, getGitHubSummary, getGitHubStats, getDailySilk, getAvailableDates, getLatestDate } from '../../lib/data-loader';
+import { getFacts, getCouncilBriefing, getHighlights, getAiNews, getGitHubSummary, getGitHubStats, getDailySilk, getAvailableDates, getLatestDate, getOgImagePath } from '../../lib/data-loader';
 
 export function getStaticPaths() {
   const dates = getAvailableDates('facts');
@@ -37,7 +37,7 @@ if (!facts) {
   return Astro.redirect('/');
 }
 
-const ogImage = `https://elizaos.news/media/daily/${date}/overall.png`;
+const ogImage = getOgImagePath(date!, 'daily') ?? `https://elizaos.news/media/daily/${date}/overall.png`;
 const description = facts.overall_summary?.substring(0, 160) || 'Daily Intelligence from the elizaOS Ecosystem';
 
 const categories = facts.categories || {} as any;


### PR DESCRIPTION
## What

1200×630 `og:image` cards for daily and council pages, generated at deploy time by `scripts/og-cards.cjs` (puppeteer + canvas template).

- Headline = first sentence of `overall_summary` (daily) / `daily_focus` (council), wrapped with [@chenglou/pretext](https://github.com/chenglou/pretext): binary-search the largest font size fitting ≤3 measured Playfair Display lines.
- Poster art (`media/daily/DATE/overall.png`) as cover-cropped background with scrim; branded newsprint fallback card when the poster is gone (7-day cleanup) — see samples below.
- Skips LLM error-placeholder facts files; incremental (`--force` to regenerate); `media/og/` is gitignored and rebuilt each deploy.
- deploy.yml: cards generate **before** the Astro build (`getOgImagePath` in `data-loader.ts` checks the files at build time), copied to dist after. `continue-on-error` so card failures never block a deploy.
- Daily pages fall back to the current `overall.png` URL; council pages gain an `og:image` for the first time.

## Why pretext

Honest note: a greedy `ctx.measureText` wrap could produce similar left-aligned output. pretext is used for the clean `lineCount` binary search, `Intl.Segmenter` grapheme correctness, and as the shared text engine for the upcoming measured-captions and broadsheet-PDF branches. It runs only in Chrome contexts (no Node target yet), bundled at runtime via esbuild.

## Verification

- Generated real cards for 2026-08-01 (poster background) and 2026-05-20 (fallback) — visually inspected.
- Incremental skip re-run confirmed.
- `npm run build`: daily 2026-08-01 → `/media/og/2026-08-01.png`; daily 2026-05-19 (no card) → falls back to `overall.png`; council 2026-08-01 → `/media/og/council-2026-08-01.png`; council pages without cards unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)