### PR TITLE
Pretext-measured trailer captions + fit-to-width headlines

### DIFF
--- a/remotion/package-lock.json
+++ b/remotion/package-lock.json
@@ -8,10 +8,12 @@
       "name": "cronjob-trailer",
       "version": "1.0.0",
       "dependencies": {
+        "@chenglou/pretext": "^0.0.8",
         "@react-three/drei": "^10.7.7",
         "@react-three/fiber": "^9.5.0",
         "@react-three/postprocessing": "^3.0.4",
         "@remotion/cli": "4.0.417",
+        "@remotion/google-fonts": "^4.0.417",
         "@remotion/media-utils": "4.0.417",
         "@remotion/player": "4.0.417",
         "@remotion/three": "4.0.417",
@@ -48,6 +50,12 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@chenglou/pretext": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/@chenglou/pretext/-/pretext-0.0.8.tgz",
+      "integrity": "sha512-yqm2GMxnPI7VHcHwe84P8ZF0JK/2d2DMKPqMN+s95jQhwDMYYXKVFVJUMEaVWckQStdsjdLav/0Vu+d9YbtGxA==",
+      "license": "MIT"
     },
     "node_modules/@dimforge/rapier3d-compat": {
       "version": "0.12.0",
@@ -765,6 +773,15 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@remotion/google-fonts": {
+      "version": "4.0.417",
+      "resolved": "https://registry.npmjs.org/@remotion/google-fonts/-/google-fonts-4.0.417.tgz",
+      "integrity": "sha512-V10VijHA2mXAcJT+QtEG+W8ng9uxDPauQpZcSXbOhFM1XxtKC6vrx6qdEbAschKiFEyDJzsSETIZJzbQCd+mIw==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "remotion": "4.0.417"
+      }
     },
     "node_modules/@remotion/licensing": {
       "version": "4.0.417",

--- a/remotion/package.json
+++ b/remotion/package.json
@@ -9,10 +9,12 @@
     "upgrade": "npx remotion upgrade"
   },
   "dependencies": {
+    "@chenglou/pretext": "^0.0.8",
     "@react-three/drei": "^10.7.7",
     "@react-three/fiber": "^9.5.0",
     "@react-three/postprocessing": "^3.0.4",
     "@remotion/cli": "4.0.417",
+    "@remotion/google-fonts": "^4.0.417",
     "@remotion/media-utils": "4.0.417",
     "@remotion/player": "4.0.417",
     "@remotion/three": "4.0.417",
@@ -24,8 +26,8 @@
     "zod": "3.22.3"
   },
   "devDependencies": {
-    "@types/react": "19.2.7",
     "@types/node": "^22.0.0",
+    "@types/react": "19.2.7",
     "typescript": "^5.8.0"
   }
 }

--- a/remotion/src/Clip.tsx
+++ b/remotion/src/Clip.tsx
@@ -12,6 +12,8 @@ import {
   Img,
 } from "remotion";
 import { resolveAsset } from "./resolveAsset";
+import { layoutCaptionWords } from "./captionLayout";
+import { captionFont, INTER_FAMILY, useFontsReady } from "./fonts";
 
 interface WordData {
   word: string;
@@ -89,7 +91,7 @@ export const Clip: React.FC<ClipProps> = ({
   thumbnailDir,
 }) => {
   const frame = useCurrentFrame();
-  const { fps, durationInFrames } = useVideoConfig();
+  const { fps, durationInFrames, width } = useVideoConfig();
 
   const clamp01 = (value: number) => Math.max(0, Math.min(1, value));
 
@@ -296,36 +298,34 @@ export const Clip: React.FC<ClipProps> = ({
     }
   }
 
-  // TikTok-style text chunking: group words into small phrases (max 4 words or until punctuation)
-  const wordsWithChunks = React.useMemo(() => {
-    if (!words) return [];
-    let currentChunkIdx = 0;
-    let wordsInCurrentChunk = 0;
-    return words.map((w, idx) => {
-      const hasPunctuation = /[.,?!]/.test(w.word);
-      const result = { ...w, chunkIndex: currentChunkIdx, originalIndex: idx };
-      wordsInCurrentChunk++;
-      if (wordsInCurrentChunk >= 4 || hasPunctuation) {
-        currentChunkIdx++;
-        wordsInCurrentChunk = 0;
-      }
-      return result;
-    });
-  }, [words]);
+  // Measured caption lines (pretext): words are broken into lines that fit
+  // the caption safe area, with per-word x-offsets for the karaoke highlight.
+  // Everything frame-independent lives in the memo so every one of the
+  // clip's frame re-renders sees identical line breaks.
+  const CAPTION_SIZE = 84;
+  const fontsReady = useFontsReady();
+  const captionSafeWidth =
+    width - (showThumbnail ? 360 : 80) - (showThumbnail ? 80 : 50);
+  const captionLayout = React.useMemo(() => {
+    if (!words || words.length === 0 || !fontsReady) return null;
+    return layoutCaptionWords(words, captionFont(CAPTION_SIZE), captionSafeWidth);
+  }, [words, captionSafeWidth, fontsReady]);
 
-  let activeChunk = 0;
-  if (wordsWithChunks.length > 0) {
+  // Active line = line containing the most recent word whose start time has
+  // passed (same timing scan the chunked captions used).
+  let activeWordIdx = 0;
+  if (words && words.length > 0) {
     const clipStartSec = startSec || 0;
-    let currentWord = wordsWithChunks[0];
-    for (const w of wordsWithChunks) {
-      if (frame >= (w.start - clipStartSec) * fps) {
-        currentWord = w;
+    for (let i = 0; i < words.length; i++) {
+      if (frame >= (words[i].start - clipStartSec) * fps) {
+        activeWordIdx = i;
       } else {
         break;
       }
     }
-    activeChunk = currentWord.chunkIndex;
   }
+  const activeLineIdx = captionLayout?.wordToLine[activeWordIdx] ?? 0;
+  const activeLine = captionLayout?.lines[activeLineIdx] ?? null;
 
   return (
     <AbsoluteFill
@@ -606,7 +606,7 @@ export const Clip: React.FC<ClipProps> = ({
         </div>
       )}
 
-      {/* Main quote text — TikTok style word chunks synced to speech */}
+      {/* Main quote text — pretext-measured line synced to speech */}
       <div
         style={{
           position: "absolute",
@@ -616,7 +616,6 @@ export const Clip: React.FC<ClipProps> = ({
           display: "flex",
           justifyContent: "center",
           alignItems: "center",
-          flexWrap: "wrap",
           transform: `translateY(${textSlide}px) scale(${textParallax})`,
           transformOrigin: "center center",
           opacity: textOpacity,
@@ -624,21 +623,65 @@ export const Clip: React.FC<ClipProps> = ({
       >
         <p
           style={{
-            fontSize: 84, // Slightly bigger text for CapCut style
+            fontSize: CAPTION_SIZE,
             fontWeight: 800,
+            fontFamily: INTER_FAMILY, // must match captionFont() for measured offsets
             color: "#fff",
             lineHeight: 1.15,
             margin: 0,
             textShadow: "0 4px 20px rgba(0,0,0,0.9), 0 2px 4px rgba(0,0,0,0.8)",
             textAlign: "center",
-            width: "100%",
+            whiteSpace: "pre",
+            position: "relative",
+            width: activeLine ? activeLine.width : "100%",
           }}
         >
-          {wordsWithChunks && wordsWithChunks.length > 0
-            ? wordsWithChunks.map((w) => {
-                if (w.chunkIndex !== activeChunk) return null;
-                const idx = w.originalIndex;
-                
+          {/* Karaoke highlight — rounded rect gliding between measured word
+              positions of the active line */}
+          {activeLine && words && (() => {
+            const clipStartSec = startSec || 0;
+            const speaking = activeLine.words.filter(
+              (lw) => frame >= (words[lw.wordIdx].start - clipStartSec) * fps,
+            );
+            const current = speaking[speaking.length - 1];
+            if (!current) return null;
+            if (frame >= (words[current.wordIdx].end - clipStartSec) * fps + 10) {
+              return null; // line finished speaking a while ago
+            }
+            const prev = speaking[speaking.length - 2];
+            const startFrame = (words[current.wordIdx].start - clipStartSec) * fps;
+            const glide = prev
+              ? Easing.bezier(0.2, 1, 0.2, 1)(
+                  Math.max(0, Math.min(1, (frame - startFrame) / 4)),
+                )
+              : 1;
+            const x = prev ? prev.x + (current.x - prev.x) * glide : current.x;
+            const w = prev
+              ? prev.width + (current.width - prev.width) * glide
+              : current.width;
+            const PAD = 14;
+            return (
+              <span
+                style={{
+                  position: "absolute",
+                  left: x - PAD,
+                  width: w + PAD * 2,
+                  top: "50%",
+                  height: "1.25em",
+                  transform: "translateY(-50%)",
+                  borderRadius: 18,
+                  backgroundColor: `${actorColor}38`,
+                  boxShadow: `0 0 24px ${actorColor}30`,
+                  zIndex: -1, // behind the word spans (their transforms lift them)
+                }}
+              />
+            );
+          })()}
+          {activeLine && words
+            ? activeLine.words.map((lw) => {
+                const idx = lw.wordIdx;
+                const w = words[idx];
+
                 // Convert absolute word time to clip-local frame
                 const clipStartSec = startSec || 0;
                 const wordStartFrame = (w.start - clipStartSec) * fps;
@@ -717,7 +760,7 @@ export const Clip: React.FC<ClipProps> = ({
                       }}
                     >
                       {w.word}
-                      {idx < wordsWithChunks.length - 1 ? "\u00A0" : ""}
+                      {lw === activeLine.words[activeLine.words.length - 1] ? "" : " "}
                     </span>
                   );
                 }
@@ -733,8 +776,9 @@ export const Clip: React.FC<ClipProps> = ({
                   wordOpacity = 0;
                   wordColor = "rgba(255,255,255,0.3)";
                 } else if (isSpeaking) {
+                  // White against the actor-colored karaoke pill behind it.
                   wordOpacity = 1;
-                  wordColor = actorColor;
+                  wordColor = "#fff";
                 } else {
                   const fadeT = Math.min(
                     1,
@@ -758,7 +802,7 @@ export const Clip: React.FC<ClipProps> = ({
                     }}
                   >
                     {w.word}
-                    {idx < wordsWithChunks.length - 1 ? "\u00A0" : ""}
+                    {lw === activeLine.words[activeLine.words.length - 1] ? "" : " "}
                   </span>
                 );
               })

--- a/remotion/src/DailyCard.tsx
+++ b/remotion/src/DailyCard.tsx
@@ -14,6 +14,7 @@ import {
   interpolate,
   staticFile,
   useCurrentFrame,
+  useVideoConfig,
 } from "remotion";
 import {
   Item,
@@ -33,6 +34,8 @@ import { GraphCanvas, buildGraphTimeline, resolveGraphCamera, OPENING_FRAMES, ge
 import { GLBFader } from "./GLBFader";
 import { buildFaderSceneBounds } from "./fader";
 import { CANVAS_SIZE } from "./graph/layout";
+import { fitFontSize } from "./fitText";
+import { headlineFont, INTER_FAMILY, useFontsReady } from "./fonts";
 
 export type { Item, DailyCardProps };
 
@@ -43,6 +46,24 @@ const ORANGE = "#FF8A00";
 export const DailyCard: React.FC<DailyCardProps> = (props) => {
   const { date, site_url } = props;
   const frame = useCurrentFrame();
+
+  // Fit-to-width headline: largest size whose measured layout stays within
+  // 3 lines of the 72px-margin content box.
+  const { width: compWidth } = useVideoConfig();
+  const fontsReady = useFontsReady();
+  const headlineSize = useMemo(
+    () =>
+      fitFontSize(
+        props.headline,
+        headlineFont,
+        compWidth - 144,
+        3,
+        1.3,
+        { min: 24, max: 48, letterSpacing: -0.5 },
+      ),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [props.headline, compWidth, fontsReady],
+  );
 
   const totalFrames = computeTotalFrames(props);
   const timeline = useMemo(() => buildGraphTimeline(props), [props]);
@@ -161,11 +182,11 @@ export const DailyCard: React.FC<DailyCardProps> = (props) => {
         >
           <p
             style={{
-              fontSize: props.headline.length < 55 ? 42 : props.headline.length < 90 ? 36 : 30,
+              fontSize: headlineSize,
               color: "#fff",
               margin: 0,
               lineHeight: 1.3,
-              fontFamily: '"Helvetica Neue", Helvetica, Arial, sans-serif',
+              fontFamily: INTER_FAMILY, // must match the font measured by fitFontSize
               fontWeight: 600,
               letterSpacing: "-0.5px",
               textShadow: `0 2px 20px rgba(0,0,0,0.7), 0 0 40px ${ORANGE}30`,

--- a/remotion/src/captionLayout.ts
+++ b/remotion/src/captionLayout.ts
@@ -1,0 +1,97 @@
+import { prepareWithSegments, layoutWithLines } from "@chenglou/pretext";
+
+export interface WordTiming {
+  word: string;
+  start: number;
+  end: number;
+}
+
+export interface LaidOutWord {
+  /** Index into the original words array. */
+  wordIdx: number;
+  /** Left edge relative to the line's left edge, in px. */
+  x: number;
+  width: number;
+}
+
+export interface CaptionLine {
+  text: string;
+  width: number;
+  words: LaidOutWord[];
+}
+
+export interface CaptionLayout {
+  lines: CaptionLine[];
+  /** wordToLine[wordIdx] -> line index. */
+  wordToLine: number[];
+}
+
+let measureCtx: OffscreenCanvasRenderingContext2D | null = null;
+function getMeasureCtx(): OffscreenCanvasRenderingContext2D {
+  if (!measureCtx) {
+    measureCtx = new OffscreenCanvas(1, 1).getContext("2d")!;
+  }
+  return measureCtx;
+}
+
+/**
+ * Break caption words into measured lines that fit maxWidth, with per-word
+ * x-offsets for karaoke highlighting. Pure arithmetic after pretext's one-time
+ * prepare — safe to call from a useMemo that must stay identical across
+ * Remotion's per-frame re-renders.
+ *
+ * Returns null when the words can't be mapped onto pretext's lines (e.g. a
+ * single word broken across lines); callers fall back to unmeasured rendering.
+ */
+export function layoutCaptionWords(
+  words: WordTiming[],
+  font: string,
+  maxWidth: number,
+): CaptionLayout | null {
+  if (!words.length || maxWidth <= 0) return null;
+
+  const tokens = words.map((w) => w.word.trim()).filter((w) => w.length > 0);
+  if (tokens.length !== words.length) return null;
+  const text = tokens.join(" ");
+
+  const prepared = prepareWithSegments(text, font);
+  // lineHeight only affects the returned height, not the breaks — pass the
+  // font size as a stand-in.
+  const fontSize = parseFloat(font.match(/(\d+(?:\.\d+)?)px/)?.[1] ?? "84");
+  const { lines } = layoutWithLines(prepared, maxWidth, fontSize);
+  if (!lines.length) return null;
+
+  const ctx = getMeasureCtx();
+  ctx.font = font;
+  const spaceWidth = ctx.measureText(" ").width;
+
+  const out: CaptionLine[] = [];
+  const wordToLine: number[] = [];
+  let wordIdx = 0;
+
+  for (const line of lines) {
+    const lineWords: LaidOutWord[] = [];
+    let x = 0;
+    // Lines are the joined text split at measured break points, so each
+    // space-separated token corresponds to one original word, in order.
+    for (const token of line.text.split(" ")) {
+      if (token === "") continue;
+      if (wordIdx >= words.length || token !== tokens[wordIdx]) {
+        return null; // a word was hyphenated/split — bail to fallback
+      }
+      const width = ctx.measureText(token).width;
+      lineWords.push({ wordIdx, x, width });
+      wordToLine[wordIdx] = out.length;
+      x += width + spaceWidth;
+      wordIdx++;
+    }
+    out.push({
+      text: line.text,
+      width: ctx.measureText(line.text).width,
+      words: lineWords,
+    });
+  }
+  if (wordIdx !== words.length) return null;
+
+  return { lines: out, wordToLine };
+}

--- a/remotion/src/fitText.ts
+++ b/remotion/src/fitText.ts
@@ -1,0 +1,45 @@
+import { prepare, layout } from "@chenglou/pretext";
+
+export interface FitOptions {
+  min: number;
+  max: number;
+  /** px letter spacing — must match the CSS letter-spacing of the target. */
+  letterSpacing?: number;
+}
+
+/**
+ * Largest font size in [min, max] whose measured layout fits within maxLines
+ * at maxWidth. Binary search; each candidate size needs its own prepare()
+ * because the size is baked into the canvas font shorthand.
+ */
+export function fitFontSize(
+  text: string,
+  fontForSize: (px: number) => string,
+  maxWidth: number,
+  maxLines: number,
+  lineHeightRatio: number,
+  opts: FitOptions,
+): number {
+  if (!text || maxWidth <= 0) return opts.min;
+  let lo = opts.min;
+  let hi = opts.max;
+  let best = opts.min;
+  while (lo <= hi) {
+    const mid = Math.floor((lo + hi) / 2);
+    const prepared = prepare(text, fontForSize(mid), {
+      letterSpacing: opts.letterSpacing,
+    });
+    const { lineCount } = layout(
+      prepared,
+      maxWidth,
+      Math.round(mid * lineHeightRatio),
+    );
+    if (lineCount > 0 && lineCount <= maxLines) {
+      best = mid;
+      lo = mid + 1;
+    } else {
+      hi = mid - 1;
+    }
+  }
+  return best;
+}

--- a/remotion/src/fonts.ts
+++ b/remotion/src/fonts.ts
@@ -1,0 +1,45 @@
+import React from "react";
+import { continueRender, delayRender } from "remotion";
+import { loadFont } from "@remotion/google-fonts/Inter";
+
+// pretext measures with the browser font engine, so the font string passed to
+// prepare() must byte-for-byte match the CSS of the text it lays out — same
+// family, weight, and px size — and the family must be loaded before measuring.
+const inter = loadFont("normal", {
+  weights: ["600", "800"],
+  subsets: ["latin"],
+});
+
+export const INTER_FAMILY = inter.fontFamily; // "Inter"
+
+export const captionFont = (px: number): string =>
+  `800 ${px}px ${INTER_FAMILY}`;
+
+export const headlineFont = (px: number): string =>
+  `600 ${px}px ${INTER_FAMILY}`;
+
+/**
+ * True once Inter is loaded. Layout memos should depend on this so Studio
+ * re-measures after the font arrives; the delayRender handle guarantees
+ * headless renders never capture a frame measured with a fallback font.
+ */
+export function useFontsReady(): boolean {
+  const [ready, setReady] = React.useState(false);
+  const [handle] = React.useState(() =>
+    delayRender("Loading Inter for pretext measurement"),
+  );
+  React.useEffect(() => {
+    let alive = true;
+    inter
+      .waitUntilDone()
+      .then(() => {
+        if (alive) setReady(true);
+        continueRender(handle);
+      })
+      .catch(() => continueRender(handle));
+    return () => {
+      alive = false;
+    };
+  }, [handle]);
+  return ready;
+}


### PR DESCRIPTION
## What

Replaces the trailer's count-based caption chunking with measured text layout via [@chenglou/pretext](https://github.com/chenglou/pretext), running natively in Remotion's Chrome renderer.

- **Measured caption lines** (`captionLayout.ts`): words break into lines that actually fit the caption safe area — no more overflow with long words. Word→line mapping drives the same timing scan the chunks used.
- **Karaoke highlight**: rounded actor-colored pill glides between measured per-word x-offsets; the speaking word renders white for contrast. CAPS flash/shake and reveal animations are unchanged.
- **Real font loading** (`fonts.ts`): captions declared Inter but never loaded it (rendered Helvetica). Now loaded via `@remotion/google-fonts` with a delayRender gate, so headless renders can't measure with a fallback font — the #1 pretext pitfall is measure/render font mismatch.
- **Fit-to-width headlines** (`fitText.ts`, `DailyCard.tsx`): binary search for the largest size fitting ≤3 measured lines, replacing `headline.length < 55 ? 42 : …` thresholds. Uses `useVideoConfig().width` (the previous draft nearly used the 5000px graph coordinate space — now the 1080px composition).
- Deterministic: all layout in `useMemo` with no frame-dependent inputs; empty/unmappable `words` falls back to the existing plain-text path.

## Verification

- `tsc --noEmit` clean.
- DailyCard still at the headline frame: 3 balanced Inter lines filling the content box.
- Trailer stills at frames 120/260 (Waifu Season config): lines fit the safe area, pill tracks the speaking word across both mid-sentence and tail lines.
- 90-frame headless segment render completes.
- Same-frame repeat renders are pixel-identical except pre-existing GLB WebGL noise (max delta 4/255, isolated to the 3D layer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)