### PR TITLE
Print-edition broadsheet PDFs with pretext-fitted headlines

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -66,6 +66,11 @@ jobs:
           ls dist/media/daily/2026-02-16/ 2>/dev/null | head -5 || echo "  No 2026-02-16 images"
           ls dist/unity/ 2>/dev/null | head -5 || echo "  No unity"
 
+      # After asset copy so the PDFs land in the final dist/media/daily/ tree.
+      - name: Render broadsheet PDFs
+        continue-on-error: true
+        run: node scripts/broadsheet/render-pdf.cjs --days 7
+
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v5
         with:

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@astrojs/react": "^4.0.0",
         "@astrojs/sitemap": "^3.7.0",
+        "@chenglou/pretext": "^0.0.8",
         "astro": "^5.0.0",
         "puppeteer-stream": "^3.0.22",
         "react": "^18.3.1",
@@ -20,6 +21,7 @@
         "@types/react": "^18.3.0",
         "@types/react-dom": "^18.3.0",
         "glob": "^13.0.0",
+        "puppeteer": "^25.4.0",
         "ts-node": "^10.9.2",
         "typescript": "^5.8.3"
       }
@@ -400,6 +402,12 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/@chenglou/pretext": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/@chenglou/pretext/-/pretext-0.0.8.tgz",
+      "integrity": "sha512-yqm2GMxnPI7VHcHwe84P8ZF0JK/2d2DMKPqMN+s95jQhwDMYYXKVFVJUMEaVWckQStdsjdLav/0Vu+d9YbtGxA==",
+      "license": "MIT"
     },
     "node_modules/@cspotcode/source-map-support": {
       "version": "0.8.1",
@@ -4059,6 +4067,19 @@
         "node": ">=6"
       }
     },
+    "node_modules/lilconfig": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
+      "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antonk52"
+      }
+    },
     "node_modules/longest-streak": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
@@ -4953,6 +4974,16 @@
       "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
       "license": "MIT"
     },
+    "node_modules/modern-tar": {
+      "version": "0.7.7",
+      "resolved": "https://registry.npmjs.org/modern-tar/-/modern-tar-0.7.7.tgz",
+      "integrity": "sha512-t9VmxaqrmANnEOBhpSDI6HD192Ge48k8vmWqQQL7hSFEqHEYwZbbsu49+aKLWZeRvFs3j1pMhXOqqF4kPlvjkQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/mrmime": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.1.tgz",
@@ -5383,6 +5414,28 @@
         "once": "^1.3.1"
       }
     },
+    "node_modules/puppeteer": {
+      "version": "25.4.0",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-25.4.0.tgz",
+      "integrity": "sha512-xfQp8dFBcGaLc1hEMaVr7s+oW4ZkAurr8Y9H81ilKhu6QoLfSTkZjU7IavnyJ/VWpB9ni3KNJUQHUatslLWyGw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@puppeteer/browsers": "3.0.6",
+        "chromium-bidi": "17.0.2",
+        "devtools-protocol": "0.0.1653615",
+        "lilconfig": "^3.1.3",
+        "puppeteer-core": "25.4.0",
+        "typed-query-selector": "^2.12.2"
+      },
+      "bin": {
+        "puppeteer": "lib/puppeteer/node/cli.js"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
     "node_modules/puppeteer-core": {
       "version": "24.43.1",
       "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-24.43.1.tgz",
@@ -5409,6 +5462,154 @@
       "dependencies": {
         "puppeteer-core": "^24.16.2",
         "ws": "^8.17.1"
+      }
+    },
+    "node_modules/puppeteer/node_modules/@puppeteer/browsers": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-3.0.6.tgz",
+      "integrity": "sha512-B/gKoqlFkzhvzsI6jo9K1cZz9o5ypviVv/xu8CwA4grZzyVwN+XfkT+tu8T1zrauuEXv6VhS2oGX+6NL95WcKA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "modern-tar": "^0.7.6",
+        "yargs": "^18.0.0"
+      },
+      "bin": {
+        "browsers": "lib/main-cli.js"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      },
+      "peerDependencies": {
+        "proxy-agent": ">=8.0.1",
+        "yauzl": "^2.10.0 || ^3.4.0"
+      },
+      "peerDependenciesMeta": {
+        "proxy-agent": {
+          "optional": true
+        },
+        "yauzl": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/puppeteer/node_modules/chromium-bidi": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-17.0.2.tgz",
+      "integrity": "sha512-5v9GQFhTktFvotn/OFNJBmKLKRAb6n9r0bVCwf7sHgWc3/JryK0bj1nn93L3pHFrfgcsu6Be6EWsDi+1XHTGDg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "mitt": "^3.0.1",
+        "zod": "^3.24.1"
+      },
+      "engines": {
+        "node": ">=20.19.0 <22.0.0 || >=22.12.0"
+      },
+      "peerDependencies": {
+        "devtools-protocol": "*"
+      }
+    },
+    "node_modules/puppeteer/node_modules/cliui": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-9.0.1.tgz",
+      "integrity": "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^7.2.0",
+        "strip-ansi": "^7.1.0",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/puppeteer/node_modules/devtools-protocol": {
+      "version": "0.0.1653615",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1653615.tgz",
+      "integrity": "sha512-pGVkY3T/qXxAp2nFPodwYqOevk6ncNMSmvL8QfRCx5ZWGd6Vor7AFNmyaA8Zs6uJyP1QAfjuLandCgvSix1BNA==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/puppeteer/node_modules/puppeteer-core": {
+      "version": "25.4.0",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-25.4.0.tgz",
+      "integrity": "sha512-K1plkLOdeoUnGeT1OvdqF3qxl33v+Ra/uH5VyPEhXdMcpvGiEskHzxxEU3fgpccJpJLIipB/rPUsvkZRWeKqOA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@puppeteer/browsers": "3.0.6",
+        "chromium-bidi": "17.0.2",
+        "devtools-protocol": "0.0.1653615",
+        "typed-query-selector": "^2.12.2",
+        "webdriver-bidi-protocol": "0.4.2",
+        "ws": "^8.21.1"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/puppeteer/node_modules/webdriver-bidi-protocol": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/webdriver-bidi-protocol/-/webdriver-bidi-protocol-0.4.2.tgz",
+      "integrity": "sha512-VSV+fzfChirL3e7jay2yUC7B4HQCGtEWEg/MSSQbK+qWbqeGlRLlXTzPpYr3XGUvbpDHumWZBJxgesg4N7dbtA==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/puppeteer/node_modules/yargs": {
+      "version": "18.1.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-18.1.0.tgz",
+      "integrity": "sha512-2rAgRKu54VsHkqI0/tYkmluGXHD4KW7yZoycuqDQ15QOTnc2VVfy0nN/1eMhnQLO00A+dwtK20xuCnc1YGeUyg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^9.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "string-width": "^8.2.1",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^22.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
+      }
+    },
+    "node_modules/puppeteer/node_modules/yargs-parser": {
+      "version": "22.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
+      "integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
+      }
+    },
+    "node_modules/puppeteer/node_modules/yargs/node_modules/string-width": {
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.2.tgz",
+      "integrity": "sha512-GaPUh5gfdrYzqeVNZvUfT23vYYxXzKYidUcnMtJg/3rxRV63EFZy3k6xfKlmfeJD0176lnUV/Usr3XcwSvFzpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.5.0",
+        "strip-ansi": "^7.1.2"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/puppeteer/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/radix3": {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "build": "astro build",
     "preview": "astro preview",
     "sync": "git -C knowledge pull --ff-only origin main",
+    "broadsheet": "node scripts/broadsheet/render-pdf.cjs",
     "record": "node scripts/recorder.cjs",
     "pipeline": "./scripts/run_pipeline.sh",
     "clip": "npx ts-node scripts/clip.ts",
@@ -22,6 +23,7 @@
   "dependencies": {
     "@astrojs/react": "^4.0.0",
     "@astrojs/sitemap": "^3.7.0",
+    "@chenglou/pretext": "^0.0.8",
     "astro": "^5.0.0",
     "puppeteer-stream": "^3.0.22",
     "react": "^18.3.1",
@@ -32,6 +34,7 @@
     "@types/react": "^18.3.0",
     "@types/react-dom": "^18.3.0",
     "glob": "^13.0.0",
+    "puppeteer": "^25.4.0",
     "ts-node": "^10.9.2",
     "typescript": "^5.8.3"
   }

--- a/scripts/broadsheet/render-pdf.cjs
+++ b/scripts/broadsheet/render-pdf.cjs
@@ -1,0 +1,140 @@
+#!/usr/bin/env node
+/**
+ * Render print-edition broadsheet PDFs from the built site.
+ *
+ * Serves dist/ locally, loads /print/<date>/ in headless Chrome, waits for
+ * fonts + the in-page pretext headline fit (data-pretext-done), and writes
+ * dist/media/daily/<date>/broadsheet.pdf (plus media/daily/ locally when the
+ * directory exists).
+ *
+ * Usage (after `npm run build`):
+ *   node scripts/broadsheet/render-pdf.cjs --days 7
+ *   node scripts/broadsheet/render-pdf.cjs --date 2026-08-01
+ *   node scripts/broadsheet/render-pdf.cjs --date 2026-08-01 --force
+ */
+
+const fs = require('node:fs');
+const path = require('node:path');
+const http = require('node:http');
+
+const ROOT = path.resolve(__dirname, '..', '..');
+const DIST = path.join(ROOT, 'dist');
+
+const MIME = {
+  '.html': 'text/html', '.css': 'text/css', '.js': 'text/javascript',
+  '.png': 'image/png', '.jpg': 'image/jpeg', '.svg': 'image/svg+xml',
+  '.json': 'application/json', '.woff2': 'font/woff2',
+};
+
+function parseArgs() {
+  const args = { days: 7, date: null, force: false };
+  const argv = process.argv.slice(2);
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === '--days') args.days = parseInt(argv[++i], 10);
+    else if (argv[i] === '--date') args.date = argv[++i];
+    else if (argv[i] === '--force') args.force = true;
+  }
+  return args;
+}
+
+function serveDist() {
+  const server = http.createServer((req, res) => {
+    const urlPath = decodeURIComponent(new URL(req.url, 'http://x').pathname);
+    let file = path.join(DIST, urlPath);
+    if (!file.startsWith(DIST)) { res.writeHead(403); return res.end(); }
+    if (fs.existsSync(file) && fs.statSync(file).isDirectory()) {
+      file = path.join(file, 'index.html');
+    }
+    if (!fs.existsSync(file)) { res.writeHead(404); return res.end('not found'); }
+    res.writeHead(200, { 'Content-Type': MIME[path.extname(file)] || 'application/octet-stream' });
+    fs.createReadStream(file).pipe(res);
+  });
+  return new Promise((resolve) => {
+    server.listen(0, '127.0.0.1', () => resolve({ server, port: server.address().port }));
+  });
+}
+
+async function main() {
+  const args = parseArgs();
+  if (!fs.existsSync(DIST)) {
+    console.error('dist/ not found — run `npm run build` first.');
+    process.exit(1);
+  }
+
+  const printDir = path.join(DIST, 'print');
+  if (!fs.existsSync(printDir)) {
+    console.error('dist/print/ not found — the build produced no print pages.');
+    process.exit(1);
+  }
+  let dates = fs.readdirSync(printDir)
+    .filter(d => /^\d{4}-\d{2}-\d{2}$/.test(d))
+    .sort()
+    .reverse();
+  dates = args.date ? dates.filter(d => d === args.date) : dates.slice(0, args.days);
+  if (dates.length === 0) {
+    console.error(args.date ? `No print page for ${args.date} in dist/.` : 'No print pages found.');
+    process.exit(1);
+  }
+
+  const { server, port } = await serveDist();
+  const puppeteer = require('puppeteer');
+  const browser = await puppeteer.launch({
+    headless: true,
+    args: ['--no-sandbox', '--force-color-profile=srgb'],
+  });
+
+  let failed = 0;
+  try {
+    const page = await browser.newPage();
+    for (const date of dates) {
+      const distOut = path.join(DIST, 'media', 'daily', date);
+      const outPath = path.join(distOut, 'broadsheet.pdf');
+      if (!args.force && fs.existsSync(outPath)) {
+        console.log(`  – ${date}: exists, skipping`);
+        continue;
+      }
+      try {
+        await page.goto(`http://127.0.0.1:${port}/print/${date}/`, {
+          waitUntil: 'networkidle0',
+          timeout: 60000,
+        });
+        // Wait for the in-page pretext fit (it also awaits document.fonts.ready).
+        await page.waitForFunction(
+          () => document.documentElement.dataset.pretextDone === '1',
+          { timeout: 30000 },
+        );
+        const fontsOk = await page.evaluate(
+          () => document.fonts.check('900 30px "Playfair Display"'),
+        );
+        if (!fontsOk) throw new Error('Playfair Display failed to load');
+
+        const pdf = await page.pdf({ preferCSSPageSize: true, printBackground: true });
+        fs.mkdirSync(distOut, { recursive: true });
+        fs.writeFileSync(outPath, pdf);
+        // Convenience copy next to the local poster assets when present.
+        const localDir = path.join(ROOT, 'media', 'daily', date);
+        if (fs.existsSync(localDir)) {
+          fs.writeFileSync(path.join(localDir, 'broadsheet.pdf'), pdf);
+        }
+        console.log(`  ✓ ${date}: ${(pdf.length / 1024).toFixed(0)} KB`);
+      } catch (err) {
+        failed++;
+        console.error(`  ✗ ${date}: ${err.message}`);
+      }
+    }
+  } finally {
+    await browser.close();
+    server.close();
+  }
+
+  if (failed === dates.length) {
+    console.error('All broadsheet renders failed.');
+    process.exit(1);
+  }
+  if (failed) console.warn(`${failed}/${dates.length} render(s) failed; the rest were written.`);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/lib/data-loader.ts
+++ b/src/lib/data-loader.ts
@@ -58,6 +58,25 @@ export function getDailySilk(date: string): string | null {
   return readText(`daily-silk/${date}.md`);
 }
 
+/** Dates with printable facts (not LLM error placeholders), newest first. */
+export function getPrintableDates(): string[] {
+  return getAvailableDates('facts').filter(date => {
+    const f = getFacts(date);
+    return f && (f as any)._metadata?.status !== 'error' && !/^Error:/i.test(f.overall_summary || '');
+  });
+}
+
+let broadsheetDatesMemo: Set<string> | null = null;
+
+/** The dates scripts/broadsheet/render-pdf.cjs will produce PDFs for at deploy
+ * time: the 7 newest printable dates. Memoized — called from every daily page. */
+export function getBroadsheetDates(): Set<string> {
+  if (!broadsheetDatesMemo) {
+    broadsheetDatesMemo = new Set(getPrintableDates().slice(0, 7));
+  }
+  return broadsheetDatesMemo;
+}
+
 export function getAvailableDates(type: 'facts' | 'council_briefing'): string[] {
   const dir = type === 'facts' ? 'the-council/facts' : 'the-council/council_briefing';
   try {

--- a/src/pages/daily/[date].astro
+++ b/src/pages/daily/[date].astro
@@ -11,7 +11,7 @@ import DevelopmentGrid from '../../components/daily/DevelopmentGrid.astro';
 import FullStories from '../../components/daily/FullStories.astro';
 import OpenQuestions from '../../components/daily/OpenQuestions.astro';
 import GitHubStatsBar from '../../components/daily/GitHubStatsBar.astro';
-import { getFacts, getCouncilBriefing, getHighlights, getAiNews, getGitHubSummary, getGitHubStats, getDailySilk, getAvailableDates, getLatestDate } from '../../lib/data-loader';
+import { getFacts, getCouncilBriefing, getHighlights, getAiNews, getGitHubSummary, getGitHubStats, getDailySilk, getAvailableDates, getLatestDate, getBroadsheetDates } from '../../lib/data-loader';
 
 export function getStaticPaths() {
   const dates = getAvailableDates('facts');
@@ -143,6 +143,11 @@ const keyFacts = facts.key_facts || [];
     </div>
     <div class="archive-nav-links">
       {prevDate && <a href={`/daily/${prevDate}`} class="archive-older">&larr; Older</a>}
+      {/* Broadsheet PDFs are rendered at deploy time for the 7 newest
+          printable editions — same selection render-pdf.cjs makes. */}
+      {getBroadsheetDates().has(date!) && (
+        <a href={`/media/daily/${date}/broadsheet.pdf`} class="archive-older">Print Edition (PDF)</a>
+      )}
       {nextDate && <a href={`/daily/${nextDate}`} class="archive-older">Newer &rarr;</a>}
     </div>
   </nav>

--- a/src/pages/print/[date].astro
+++ b/src/pages/print/[date].astro
@@ -1,0 +1,211 @@
+---
+// Print-edition broadsheet — rendered to PDF by scripts/broadsheet/render-pdf.cjs.
+// Standalone page (no site chrome); layout is CSS multicol, with pretext
+// fitting the lead headline to exactly <=2 lines after fonts load.
+import '../../styles/broadsheet.css';
+import { getFacts, getCouncilBriefing, getAvailableDates, getPrintableDates } from '../../lib/data-loader';
+import { formatDateLong } from '../../lib/dates';
+
+export function getStaticPaths() {
+  // Only dates with real content — LLM error placeholders aren't worth printing.
+  return getPrintableDates().map(date => ({ params: { date } }));
+}
+
+const { date } = Astro.params;
+const facts = getFacts(date!);
+const councilBriefing = getCouncilBriefing(date!);
+
+if (!facts) {
+  return Astro.redirect('/');
+}
+
+const categories = facts.categories || ({} as any);
+const summary = facts.overall_summary || '';
+const headlineMatch = summary.match(/^(.+?[.!?])(?=\s|$)/);
+const leadHeadline = (headlineMatch ? headlineMatch[1] : summary.substring(0, 120)).trim();
+const leadBody = headlineMatch ? summary.substring(headlineMatch[0].length).trim() : '';
+
+const strategyText = (item: any) =>
+  item.insight || item.observation || item.analysis || item.summary || '';
+
+const issueNumber = getAvailableDates('facts').length;
+---
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>elizaOS News — Print Edition {date}</title>
+    <meta name="robots" content="noindex" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@700;900&family=IBM+Plex+Serif:ital,wght@0,400;0,600;1,400&family=DM+Sans:wght@500;700&display=swap"
+      rel="stylesheet"
+    />
+  </head>
+  <body class="broadsheet">
+    <header class="bs-masthead">
+      <h1>elizaOS News</h1>
+      <div class="bs-dateline">
+        <span>Print Edition</span>
+        <span>{formatDateLong(date!)}</span>
+        <span>No. {issueNumber}</span>
+      </div>
+    </header>
+
+    <section class="bs-lead">
+      <h2 class="bs-lead-headline" id="lead-headline">{leadHeadline}</h2>
+      <div class="bs-lead-body">
+        <img
+          class="bs-lead-poster"
+          src={`/media/daily/${date}/overall.png`}
+          alt=""
+          onerror="this.style.display='none'"
+        />
+        <p>{leadBody || summary}</p>
+      </div>
+    </section>
+
+    <main class="bs-columns">
+      {(facts.key_facts?.length ?? 0) > 0 && (
+        <section class="bs-section">
+          <h3 class="bs-section-title">Key Facts</h3>
+          <ol class="bs-facts-list">
+            {facts.key_facts.map(f => <li>{f}</li>)}
+          </ol>
+        </section>
+      )}
+
+      {councilBriefing?.daily_focus && (
+        <aside class="bs-council">
+          <h3 class="bs-section-title">The Council</h3>
+          <p class="bs-council-focus">{councilBriefing.daily_focus}</p>
+          {(councilBriefing.key_points || []).slice(0, 3).map(kp => (
+            <div class="bs-item">
+              <div class="bs-item-head">{kp.topic}</div>
+              <div>{kp.summary}</div>
+            </div>
+          ))}
+        </aside>
+      )}
+
+      {(categories.strategic_insights?.length ?? 0) > 0 && (
+        <section class="bs-section">
+          <h3 class="bs-section-title">Strategic Insights</h3>
+          {categories.strategic_insights.map((item: any) => (
+            <div class="bs-item">
+              {item.theme && <div class="bs-item-head">{item.theme}</div>}
+              <div>{strategyText(item)}</div>
+            </div>
+          ))}
+        </section>
+      )}
+
+      {(categories.market_analysis?.length ?? 0) > 0 && (
+        <section class="bs-section">
+          <h3 class="bs-section-title">Market Analysis</h3>
+          {categories.market_analysis.map((item: any) => (
+            <div class="bs-item">
+              <div>{strategyText(item)}</div>
+            </div>
+          ))}
+        </section>
+      )}
+
+      {(categories.twitter_news_highlights?.length ?? 0) > 0 && (
+        <section class="bs-section">
+          <h3 class="bs-section-title">X News</h3>
+          {categories.twitter_news_highlights.map((item: any) => (
+            <div class="bs-item">
+              <div>{item.claim}</div>
+              {item.source && <div class="bs-item-src">{item.source}</div>}
+            </div>
+          ))}
+        </section>
+      )}
+
+      {(categories.discord_updates?.length ?? 0) > 0 && (
+        <section class="bs-section">
+          <h3 class="bs-section-title">Discord Dispatch</h3>
+          {categories.discord_updates.map((item: any) => (
+            <div class="bs-item">
+              <div class="bs-item-head">#{String(item.channel || 'unknown').replace(/^#+/, '')}</div>
+              <div>{item.summary}</div>
+            </div>
+          ))}
+        </section>
+      )}
+
+      {(categories.user_feedback?.length ?? 0) > 0 && (
+        <section class="bs-section">
+          <h3 class="bs-section-title">User Feedback</h3>
+          {categories.user_feedback.map((item: any) => (
+            <div class="bs-item">
+              <div>{item.feedback_summary}</div>
+              {item.sentiment && <div class="bs-item-src">{item.sentiment}</div>}
+            </div>
+          ))}
+        </section>
+      )}
+
+      {(facts.open_questions?.length ?? 0) > 0 && (
+        <section class="bs-section">
+          <h3 class="bs-section-title">Open Questions</h3>
+          <ol class="bs-facts-list">
+            {facts.open_questions.map(q => <li>{q}</li>)}
+          </ol>
+        </section>
+      )}
+    </main>
+
+    <footer class="bs-footer">
+      <span>elizaos.news/daily/{date}</span>
+      <span>AI-generated daily intelligence briefing — elizaOS ecosystem</span>
+    </footer>
+
+    <script>
+      // Fit the lead headline to the largest Playfair size making exactly <=2
+      // measured lines, then signal readiness to the PDF renderer via a data
+      // attribute it waits on. pretext requires the measuring font string to
+      // match the rendered CSS and be loaded first.
+      import { prepare, layout } from '@chenglou/pretext';
+
+      const FAMILY = '"Playfair Display"';
+      const done = () => {
+        document.documentElement.dataset.pretextDone = '1';
+      };
+
+      async function fitLeadHeadline() {
+        const el = document.getElementById('lead-headline');
+        if (!el) return done();
+        await document.fonts.load(`900 30px ${FAMILY}`, el.textContent || 'x');
+        await document.fonts.ready;
+        if (!document.fonts.check(`900 30px ${FAMILY}`)) {
+          console.error('Playfair Display not available; keeping CSS font size');
+          return done();
+        }
+        const text = (el.textContent || '').trim();
+        const maxWidth = el.clientWidth;
+        let lo = 24, hi = 72, best = 24;
+        while (lo <= hi) {
+          const mid = (lo + hi) >> 1;
+          const prepared = prepare(text, `900 ${mid}px ${FAMILY}`);
+          const { lineCount } = layout(prepared, maxWidth, Math.round(mid * 1.05));
+          if (lineCount > 0 && lineCount <= 2) {
+            best = mid;
+            lo = mid + 1;
+          } else {
+            hi = mid - 1;
+          }
+        }
+        el.style.fontSize = `${best}px`;
+        done();
+      }
+
+      fitLeadHeadline().catch((err) => {
+        console.error('pretext headline fit failed:', err);
+        done();
+      });
+    </script>
+  </body>
+</html>

--- a/src/styles/broadsheet.css
+++ b/src/styles/broadsheet.css
@@ -1,0 +1,147 @@
+/* Print-edition broadsheet — 11x17in (Tabloid) with 0.5in margins.
+   Designed for headless-Chrome page.pdf(); also usable via browser print. */
+
+@page {
+  size: 11in 17in;
+  margin: 0.5in;
+}
+
+.broadsheet {
+  --bs-ink: #121212;
+  --bs-faint: #6b6455;
+  --bs-rule: #121212;
+  font-family: 'IBM Plex Serif', Georgia, serif;
+  color: var(--bs-ink);
+  background: #fff;
+  font-size: 9.5pt;
+  line-height: 1.35;
+}
+
+@media screen {
+  /* Preview approximation on screen: page-width column on grey */
+  body:has(.broadsheet) { background: #888; }
+  .broadsheet {
+    width: 10in;
+    margin: 0.25in auto;
+    padding: 0.5in;
+    box-shadow: 0 2px 24px rgba(0, 0, 0, 0.4);
+  }
+}
+
+/* ── Masthead ── */
+.bs-masthead {
+  text-align: center;
+  border-bottom: 4px double var(--bs-rule);
+  padding-bottom: 10pt;
+  margin-bottom: 12pt;
+}
+.bs-masthead h1 {
+  font-family: 'Playfair Display', serif;
+  font-weight: 900;
+  font-size: 44pt;
+  letter-spacing: 0.01em;
+  margin: 0;
+}
+.bs-masthead .bs-dateline {
+  display: flex;
+  justify-content: space-between;
+  font-family: 'DM Sans', sans-serif;
+  font-size: 8pt;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  border-top: 1px solid var(--bs-rule);
+  margin-top: 8pt;
+  padding-top: 5pt;
+}
+
+/* ── Lead ── */
+.bs-lead {
+  border-bottom: 2px solid var(--bs-rule);
+  padding-bottom: 12pt;
+  margin-bottom: 12pt;
+}
+.bs-lead-headline {
+  font-family: 'Playfair Display', serif;
+  font-weight: 900;
+  font-size: 30px; /* pretext fit script overrides to exactly <=2 lines */
+  line-height: 1.05;
+  margin: 0 0 8pt;
+}
+.bs-lead-body {
+  columns: 3;
+  column-gap: 18pt;
+  column-rule: 1px solid #d8d2c4;
+  text-align: justify;
+  hyphens: auto;
+}
+.bs-lead-poster {
+  width: 100%;
+  margin: 0 0 8pt;
+  border: 1px solid var(--bs-rule);
+}
+
+/* ── Column flow ── */
+.bs-columns {
+  columns: 5;
+  column-gap: 16pt;
+  column-rule: 1px solid #d8d2c4;
+  text-align: justify;
+  hyphens: auto;
+}
+.bs-section {
+  break-inside: avoid;
+  margin-bottom: 12pt;
+}
+.bs-section-title {
+  font-family: 'Playfair Display', serif;
+  font-weight: 700;
+  font-size: 12pt;
+  border-bottom: 2px solid var(--bs-rule);
+  margin: 0 0 6pt;
+  padding-bottom: 2pt;
+  text-align: left;
+}
+.bs-item { margin-bottom: 6pt; }
+.bs-item-head {
+  font-family: 'DM Sans', sans-serif;
+  font-weight: 700;
+  font-size: 8.5pt;
+  text-align: left;
+}
+.bs-item-src {
+  font-family: 'DM Sans', sans-serif;
+  font-size: 7pt;
+  color: var(--bs-faint);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+.bs-facts-list {
+  margin: 0;
+  padding-left: 12pt;
+}
+.bs-facts-list li { margin-bottom: 4pt; }
+
+/* Council box */
+.bs-council {
+  border: 2px solid var(--bs-rule);
+  padding: 8pt;
+  break-inside: avoid;
+  margin-bottom: 12pt;
+}
+.bs-council .bs-section-title { border-bottom: 1px solid var(--bs-rule); }
+.bs-council-focus {
+  font-style: italic;
+  margin-bottom: 6pt;
+}
+
+/* ── Footer ── */
+.bs-footer {
+  border-top: 4px double var(--bs-rule);
+  margin-top: 14pt;
+  padding-top: 6pt;
+  font-family: 'DM Sans', sans-serif;
+  font-size: 7.5pt;
+  color: var(--bs-faint);
+  display: flex;
+  justify-content: space-between;
+}


### PR DESCRIPTION
## What

A daily **print edition**: `/print/[date]` renders an 11×17" broadsheet (double-rule masthead, lead story + poster, 5 justified columns of key facts / council / insights / market / X / Discord / feedback / open questions), and `scripts/broadsheet/render-pdf.cjs` turns the 7 newest editions into `media/daily/<date>/broadsheet.pdf` at deploy time. Daily pages link to it from the archive nav.

## pretext integration

An in-page module script (Astro-bundled [@chenglou/pretext](https://github.com/chenglou/pretext)) binary-searches the lead Playfair Display headline to the largest size fitting **≤2 measured lines** — the one layout decision CSS can't make — after `document.fonts.ready`, then sets `data-pretext-done` which the PDF renderer waits on. The renderer hard-fails a date if Playfair didn't actually load (no silent fallback-font PDFs).

## Design notes

- Print pages exist only for **printable** dates (upstream LLM error placeholders skipped) — `getPrintableDates()` in data-loader.
- The daily-page link is gated by memoized `getBroadsheetDates()` (7 newest printable dates), exactly matching the renderer's selection — no 404 links during upstream error streaks like this July's.
- Renderer runs **after** the asset-copy step so PDFs land in the final `dist/media/daily/` tree; `continue-on-error` so it can never block a deploy.
- Phase 2 (separate branch later): full `layoutNextLineRange` column-flow engine — page-filling layouts, text wrapping around poster cutouts, `prepareRichInline` datelines.

## Verification

- `npm run build` → 1613 pages including `/print/*`.
- `node scripts/broadsheet/render-pdf.cjs --date 2026-08-01` → 788 KB single-page PDF, exactly 792×1224 pt (11×17"), visually inspected: masthead, fitted headline, poster, balanced columns, footer.
- No-poster date (2026-07-08) renders with the lead image hidden (159 KB).
- Link gating: present on `daily/2026-08-01`, absent on error-date `2026-07-31` and old `2026-05-19`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)